### PR TITLE
added -L to find command when /tmp maybe be a symlink (e.g., OS X)

### DIFF
--- a/src/stamp.js
+++ b/src/stamp.js
@@ -65,7 +65,7 @@ class Stamp {
     burst() {
         return new Promise((fulfill, reject) => {
             let documentId = path_1.basename(this.pdf, '.pdf');
-            let command = `pdftk ${this.pdf} burst output /tmp/${documentId}-pg_%d.pdf && find /tmp -name '${documentId}-pg_*.pdf'`;
+            let command = `pdftk ${this.pdf} burst output /tmp/${documentId}-pg_%d.pdf && find -L /tmp -name '${documentId}-pg_*.pdf'`;
             child_process_1.exec(command, (error, stdin, stderr) => {
                 fulfill(stdin.split('\n')
                     .filter(x => x.length > 0));

--- a/src/stamp.ts
+++ b/src/stamp.ts
@@ -94,7 +94,7 @@ export class Stamp {
 	burst(): Promise<string[]> {
 		return new Promise( ( fulfill, reject ) => {
 			let documentId = basename( this.pdf, '.pdf' )
-			let command = `pdftk ${this.pdf} burst output /tmp/${documentId}-pg_%d.pdf && find /tmp -name '${documentId}-pg_*.pdf'`
+			let command = `pdftk ${this.pdf} burst output /tmp/${documentId}-pg_%d.pdf && find -L /tmp -name '${documentId}-pg_*.pdf'`
 			exec( command, ( error, stdin, stderr ) => {
 				fulfill( stdin.split( '\n' )
 					.filter( x => x.length > 0 ) )


### PR DESCRIPTION
/tmp maybe be a symlink in which case find -L will dereference allowing Stamp to work on OS X