### PR TITLE
Add option to force stamp and concat output files to /tmp directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "precommit-hook": "3.0.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.3",
-    "typescript": "^2.4"
+    "typescript": "^2.5.3"
   },
   "dependencies": {
     "commonpdf_pdftk": "0.0.0",

--- a/src/concat.js
+++ b/src/concat.js
@@ -16,7 +16,7 @@ const uuid_1 = require("uuid");
 const fs = require("fs");
 const sign_1 = require("./sign");
 class Concat {
-    constructor(docs, options, signOpts, outfile) {
+    constructor(docs, options, signOpts, outfile, forcetmp) {
         this.docs = docs;
         this.options = options;
         this.signOpts = signOpts;
@@ -37,7 +37,10 @@ class Concat {
             this.options = [];
         if (this.docs.length > 1 && this.options.length > 0)
             throw new Error('Can not concat and split. Try, concatenating first, and splitting afterwards.');
-        this.out = (outfile && outfile.substr(0, 4) === '/tmp') ? outfile : `/tmp/${outfile || uuid_1.v4()}.pdf`;
+        if (outfile && forcetmp !== undefined && !forcetmp)
+            this.out = outfile;
+        else
+            this.out = (outfile && outfile.substr(0, 4) === '/tmp') ? outfile : `/tmp/${outfile || uuid_1.v4()}.pdf`;
         if (signOpts) {
             this.postProcessSigning = true;
         }

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -19,7 +19,7 @@ export class Concat {
 	constructor( public docs: Array<FilePath>,
 				 public options?: Array<{ start: number, end: number | string }>,
 				 public signOpts?: SignOptions & { cert: FilePath, key: FilePath },
-				 outfile?: FilePath ) {
+				 outfile?: FilePath, forcetmp?: boolean ) {
 
 		this.docs = docs.map( doc => {
 			if ( !fs.existsSync( doc ) ) throw new Error( `File not found ${doc}` )
@@ -36,7 +36,8 @@ export class Concat {
 		if ( this.docs.length > 1 && this.options.length > 0 )
 			throw new Error( 'Can not concat and split. Try, concatenating first, and splitting afterwards.' )
 
-		this.out = (outfile && outfile.substr( 0, 4 ) === '/tmp') ? outfile : `/tmp/${outfile || id()}.pdf`
+		if ( outfile && forcetmp !== undefined && !forcetmp ) this.out = outfile
+		else this.out = (outfile && outfile.substr( 0, 4 ) === '/tmp') ? outfile : `/tmp/${outfile || id()}.pdf`
 
 		if ( signOpts ) {
 			this.postProcessSigning = true

--- a/src/stamp.js
+++ b/src/stamp.js
@@ -18,12 +18,17 @@ class Stamp {
      *
      * @param {String} contract - pdf stamping data contract
      * @param {String} [outfile] - out put file location. Defaults to /tmp
+     * @param {Boolean} [forcetmp] - force the outfile to /tmp if true
      */
-    constructor(contract, outfile) {
+    constructor(contract, outfile, forcetmp) {
         this.contract = contract;
         this.pdf = contract.file;
         this.target = null;
-        this.out = (outfile && outfile.substr(0, 4) === '/tmp') ? outfile : `/tmp/${outfile || uuid_1.v4()}.pdf`;
+        this.forcetmp = (forcetmp === undefined) ? true : forcetmp;
+        if (outfile && !this.forcetmp)
+            this.out = outfile;
+        else
+            this.out = (outfile && outfile.substr(0, 4) === '/tmp') ? outfile : `/tmp/${outfile || uuid_1.v4() + '.pdf'}`;
     }
     /**
      * @desc Generates a new pdf with image at the provided coordinates and dimensions
@@ -96,7 +101,7 @@ class Stamp {
                     let pageIndex = Stamp.pageIndex(item), targetIndex = Stamp.pageIndex(this.target);
                     accum[pageIndex] = pageIndex === targetIndex ? stampedPage : item;
                     return accum;
-                }, []), null, null, this.out).write();
+                }, []), null, null, this.out, this.forcetmp).write();
             })
                 .then(final => {
                 Promise.all(pages.map(p => fs_1.unlink(p, err => {

--- a/src/stamp.ts
+++ b/src/stamp.ts
@@ -41,16 +41,20 @@ export class Stamp {
 	public target: string
 	public out: FilePath
 	public pdf: FilePath
+	public forcetmp: boolean
 
 	/**
 	 *
 	 * @param {String} contract - pdf stamping data contract
 	 * @param {String} [outfile] - out put file location. Defaults to /tmp
+	 * @param {Boolean} [forcetmp] - force the outfile to /tmp if true
 	 */
-	constructor( public contract: StampContract, outfile?: FilePath ) {
+	constructor( public contract: StampContract, outfile?: FilePath, forcetmp?: boolean ) {
 		this.pdf = contract.file
-		this.target = null
-		this.out = (outfile && outfile.substr( 0, 4 ) === '/tmp') ? outfile : `/tmp/${outfile || id()}.pdf`
+	        this.target = null
+		this.forcetmp = (forcetmp === undefined) ? true : forcetmp
+		if ( outfile && !this.forcetmp ) this.out = outfile
+		else this.out = (outfile && outfile.substr( 0, 4 ) === '/tmp') ? outfile : `/tmp/${outfile || id() + '.pdf'}`
 	}
 
 	/**
@@ -126,7 +130,7 @@ export class Stamp {
 							targetIndex = Stamp.pageIndex( this.target )
 						accum[ pageIndex ] = pageIndex === targetIndex ? stampedPage : item
 						return accum
-					}, [] ), null, null, this.out ).write()
+					}, [] ), null, null, this.out, this.forcetmp ).write()
 				} )
 				.then( final => {
 					Promise.all( pages.map( p => unlink( p, err => {


### PR DESCRIPTION
Add forcetmp parameter to Stamp and Concat constructors to optionally force (default=True) outfile to the /tmp directory