### PR TITLE
Support for multi-word reason sign parameter and ability to call setup() locally

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -1,8 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function setup() {
-    const commonPdfPodofo = `${process.env['LAMBDA_TASK_ROOT']}/node_modules/commonpdf_podofo`;
-    const commonPdfPdftk = `${process.env['LAMBDA_TASK_ROOT']}/node_modules/commonpdf_pdftk`;
+    const commonPdfPodofo = `${process.env['LAMBDA_TASK_ROOT'] || __dirname}/node_modules/commonpdf_podofo`;
+    const commonPdfPdftk = `${process.env['LAMBDA_TASK_ROOT'] || __dirname}/node_modules/commonpdf_pdftk`;
     process.env['PATH'] = `${process.env['PATH']}:${commonPdfPdftk}:${commonPdfPodofo}`;
     process.env['LD_LIBRARY_PATH'] = `${commonPdfPodofo}:${commonPdfPdftk}`;
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,6 +1,6 @@
 export function setup() {
-	const commonPdfPodofo = `${process.env[ 'LAMBDA_TASK_ROOT' ]}/node_modules/commonpdf_podofo`
-	const commonPdfPdftk = `${process.env[ 'LAMBDA_TASK_ROOT' ]}/node_modules/commonpdf_pdftk`
+	const commonPdfPodofo = `${process.env[ 'LAMBDA_TASK_ROOT' ] || __dirname}/node_modules/commonpdf_podofo`
+	const commonPdfPdftk = `${process.env[ 'LAMBDA_TASK_ROOT' ] || __dirname}/node_modules/commonpdf_pdftk`
 	process.env[ 'PATH' ] = `${process.env[ 'PATH' ]}:${commonPdfPdftk}:${commonPdfPodofo}`
 	process.env[ 'LD_LIBRARY_PATH' ] = `${commonPdfPodofo}:${commonPdfPdftk}`
 }

--- a/src/sign.js
+++ b/src/sign.js
@@ -27,7 +27,7 @@ class Sign {
             if (this.opt.password)
                 this.commandOpts += ` -password ${this.opt.password}`;
             if (this.opt.reason)
-                this.commandOpts += ` -reason ${this.opt.reason}`;
+                this.commandOpts += ` -reason "${this.opt.reason}"`;
             if (this.opt.useExistingSignatureField)
                 this.commandOpts += ' -field-use-existing';
         }

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -23,7 +23,7 @@ export class Sign {
         if(this.opt) {
             if(this.opt.fieldName) this.commandOpts += ` -field-name ${this.opt.fieldName}`
             if(this.opt.password) this.commandOpts += ` -password ${this.opt.password}`
-            if(this.opt.reason) this.commandOpts += ` -reason ${this.opt.reason}`
+            if(this.opt.reason) this.commandOpts += ` -reason "${this.opt.reason}"`
             if(this.opt.useExistingSignatureField) this.commandOpts += ' -field-use-existing'
         }
     }


### PR DESCRIPTION
I don't see any build script so I have rebuilt js files with simple `tsc` command
Tests didn't work on fresh checkout, so I have ignored running tests